### PR TITLE
Add simple Flask website to show scraped obits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+obituaries.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# obit-crm
+# Obituary Scraper
+
+This project includes a simple Flask application that scrapes obituary
+information from several websites. Scraped data is stored in a local
+SQLite database and displayed on a web page.
+
+## Running
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the application:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in your browser. Click **Run Scraper** to
+   trigger scraping. The table of obituaries refreshes on each page load.

--- a/app.py
+++ b/app.py
@@ -1,26 +1,8 @@
-from flask import Flask, render_template_string, redirect, url_for
+from flask import Flask, render_template, redirect, url_for
 
 from obit_scraper import ObituaryScraper, ObituaryDatabase
 
 app = Flask(__name__)
-
-INDEX_TEMPLATE = """
-<!doctype html>
-<title>Obituary Scraper</title>
-<h1>Obituary Records</h1>
-<a href="{{ url_for('run_scraper') }}">Run Scraper</a>
-<table border="1" cellpadding="5">
-    <tr><th>First Name</th><th>Last Name</th><th>Date of Death</th><th>URL</th></tr>
-    {% for row in rows %}
-    <tr>
-        <td>{{ row[1] }}</td>
-        <td>{{ row[2] }}</td>
-        <td>{{ row[3] }}</td>
-        <td><a href="{{ row[4] }}" target="_blank">link</a></td>
-    </tr>
-    {% endfor %}
-</table>
-"""
 
 @app.route('/')
 def index():
@@ -29,7 +11,7 @@ def index():
     cur.execute('SELECT * FROM obituaries ORDER BY id DESC')
     rows = cur.fetchall()
     db.close()
-    return render_template_string(INDEX_TEMPLATE, rows=rows)
+    return render_template('index.html', rows=rows)
 
 @app.route('/run')
 def run_scraper():

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+    <title>Obituary Scraper</title>
+    <style>
+        table { border-collapse: collapse; }
+        th, td { padding: 4px 8px; border: 1px solid #ccc; }
+    </style>
+</head>
+<body>
+    <h1>Obituary Records</h1>
+    <p><a href="{{ url_for('run_scraper') }}">Run Scraper</a></p>
+    <table>
+        <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Date of Death</th>
+            <th>URL</th>
+        </tr>
+        {% for row in rows %}
+        <tr>
+            <td>{{ row[1] }}</td>
+            <td>{{ row[2] }}</td>
+            <td>{{ row[3] }}</td>
+            <td><a href="{{ row[4] }}" target="_blank">link</a></td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a Flask app with `/` and `/run`
- add HTML template for displaying obituary records
- ignore generated files and document usage in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843ee953b40832187162b38e8727178