### PR TITLE
Fix run scraper link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <title>Obituary Scraper</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
     <div class="container">
         <h1>Obituary Records</h1>
-        <p><a class="button" href="{{ url_for('run_scraper') }}">Run Scraper</a></p>
+        <p><a class="button" href="/run">Run Scraper</a></p>
         <table>
             <thead>
                 <tr>


### PR DESCRIPTION
## Summary
- link to `/run` directly instead of relying on Jinja's `url_for`

## Testing
- `python -m py_compile app.py obit_scraper.py`
- `python app.py` *(runs Flask server)*

------
https://chatgpt.com/codex/tasks/task_e_6843f11584548321a67ace340a853eea