### PR TITLE
Warn against Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ served by Flask.
 
 ## Prerequisites
 
-- Python 3.8 or later
+- Python 3.8–3.11
 - Google Chrome (required for Selenium)
 - (Optional) `venv` or another virtual environment tool
+
+> **Note:** Python 3.12 is currently unsupported because several
+> dependencies still import `distutils`. Use Python 3.8–3.11 or install an
+> older `setuptools` that bundles `distutils`:
+>
+> ```bash
+> python3.11 -m venv venv
+> source venv/bin/activate
+> pip install 'setuptools<60'
+> ```
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- warn that Python 3.12 isn't supported because dependencies use `distutils`
- recommend Python 3.8–3.11 or an older `setuptools`
- show how to activate such an environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844937a99c88321b0f39e77fb7a7ce7